### PR TITLE
Fix workflow sample notebook url

### DIFF
--- a/tutorials/workflow/Dockerfile
+++ b/tutorials/workflow/Dockerfile
@@ -50,7 +50,7 @@ COPY argo-pns.yaml argo-pns.yaml
 COPY soopervisor-workflow.yaml soopervisor-workflow.yaml
 
 # get sample notebook
-RUN wget https://raw.githubusercontent.com/ploomber/soorgeon/main/_kaggle/titanic-logistic-regression-with-python/nb.py
+RUN wget https://raw.githubusercontent.com/ploomber/ci-notebooks/master/titanic-logistic-regression-with-python/nb.py
 RUN jupytext nb.py --to ipynb
 RUN rm -f nb.py
 


### PR DESCRIPTION
## Describe your changes
I was following this [tutorial](https://soopervisor.readthedocs.io/en/latest/tutorials/workflow.html) to build the docker image with `docker build --tag ploomber-workflow .` in `tutorials/workflow`

It failed while downloading a notebook.
![image](https://user-images.githubusercontent.com/21193371/176260166-4b60c849-1a78-4971-9449-4d7a19d766a9.png)

Looks like it is due to the migration of these notebooks from the [ploomber/soorgeon](https://github.com/ploomber/soorgeon) repo to the [ploomber/ci-notebooks](https://github.com/ploomber/ci-notebooks) repo.

I updated the notebook URL to link to the [ci-notebooks](https://github.com/ploomber/ci-notebooks) repo.

I think we also need CI for building docker images to prevent issues like from happening.


## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

