### PR TITLE
add early error message if docker is missing 

### DIFF
--- a/src/soopervisor/airflow/export.py
+++ b/src/soopervisor/airflow/export.py
@@ -71,6 +71,8 @@ class AirflowExporter(abc.AbstractExporter):
         """
         with Commander(workspace=env_name,
                        templates_path=('soopervisor', 'assets')) as e:
+            commons.docker.validate_installation(e)
+
             tasks, args = commons.load_tasks(cmdr=e,
                                              name=env_name,
                                              mode=mode,

--- a/src/soopervisor/argo/export.py
+++ b/src/soopervisor/argo/export.py
@@ -48,6 +48,7 @@ class ArgoWorkflowsExporter(abc.AbstractExporter):
 
         with Commander(workspace=env_name,
                        templates_path=('soopervisor', 'assets')) as cmdr:
+            docker.validate_installation(cmdr)
 
             tasks, args = commons.load_tasks(cmdr=cmdr,
                                              name=env_name,

--- a/src/soopervisor/aws/batch.py
+++ b/src/soopervisor/aws/batch.py
@@ -247,6 +247,8 @@ class AWSBatchExporter(abc.AbstractExporter):
                 lazy_import):
         with Commander(workspace=env_name,
                        templates_path=('soopervisor', 'assets')) as cmdr:
+            docker.validate_installation(cmdr)
+
             tasks, cli_args = commons.load_tasks(cmdr=cmdr,
                                                  name=env_name,
                                                  mode=mode,

--- a/src/soopervisor/commons/docker.py
+++ b/src/soopervisor/commons/docker.py
@@ -31,6 +31,23 @@ def modify_wildcard(entity):
     return entity.replace("*", "ploomber")
 
 
+def validate_installation(cmdr):
+    """ valdiate if docker is installed.
+
+    Paramemters
+    -----------
+    cmdr : Commander
+           Commander instance
+    """
+
+    cmdr.run(
+        'docker --version | awk \'NR==1{print $1}\'',
+        capture_output=True,
+        expected_output="Docker",
+        error_message="Did you install Docker?",
+    )
+
+
 def get_dependencies():
     """
     Fetch all dependency files and corresponding lock files

--- a/src/soopervisor/kubeflow/export.py
+++ b/src/soopervisor/kubeflow/export.py
@@ -49,6 +49,8 @@ class KubeflowExporter(abc.AbstractExporter):
         """
         with Commander(workspace=env_name,
                        templates_path=('soopervisor', 'assets')) as e:
+            commons.docker.validate_installation(e)
+
             tasks, args = commons.load_tasks(cmdr=e, name=env_name, mode=mode)
             dag, relative_path = commons.load_dag(cmdr=e,
                                                   name=env_name,


### PR DESCRIPTION
## Describe your changes
src/soopervisor/commons: **docker.py**

Add new method `validate_installation()`, which takes `Commander` instance
as argument.
For backends using Docker, `validate_installation()` will be called at the begining of `export()`
method.

src/soopervisor: **airflow/export.py**, **argo/export.py**, **aws/batch.py**
, **kubeflow/export.py**

Invoke `validate_installation()` at the begining of `export()` method.

## Issue ticket number and link
Closes #72 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

