### PR TITLE
Use the configured repository when running exporting AWS Batch jobs with `--skip-docker`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ CHANGELOG
 0.9.4dev
 --------
 
+* Feature - `--skip-docker` uses the configured repository in soopervisor.yaml when exporting to AWS Batch. (by @DennisJLi)
+
 0.9.3 (2024-09-18)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     "tqdm",
     "pydantic",
     "Jinja2",
-    "pyyaml",
+    "pyyaml>=6.0.2",
     "ploomber>=0.14.6",
     "ploomber-core>=0.0.11",
     # sdist is generated using python -m build, so adding this here.

--- a/src/soopervisor/assets/airflow/kubernetes.py
+++ b/src/soopervisor/assets/airflow/kubernetes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from airflow import DAG
 from airflow.utils.dates import days_ago
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
 )
 

--- a/src/soopervisor/aws/batch.py
+++ b/src/soopervisor/aws/batch.py
@@ -280,13 +280,11 @@ class AWSBatchExporter(abc.AbstractExporter):
                     "submit all tasks regardless of status"
                 )
             if skip_docker:
-                pkg_name, version = source.find_package_name_and_version()
+                pkg_name, _ = source.find_package_name_and_version()
+                image = f"{cfg.repository}:latest"
                 default_image_key = get_default_image_key()
-                if default_image_key:
-                    image_local = f"{pkg_name}:{version}-"
-                    f"{docker.modify_wildcard(default_image_key)}"
                 image_map = {}
-                image_map[default_image_key] = image_local
+                image_map[default_image_key] = image
             else:
                 pkg_name, image_map = docker.build(
                     cmdr,

--- a/tests/airflow/test_airflow_export.py
+++ b/tests/airflow/test_airflow_export.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import json
 
 from airflow import DAG
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
 )
 from airflow.operators.bash import BashOperator


### PR DESCRIPTION
## Describe your changes
The soopervisor.yaml file for AWS Batch expects a `repository`, but when running `soopervisor export ... --skip-docker` the `repository` setting is not used as the image name, instead the default package is. This causes issues if we want to package the Docker container and submit to ECR repositories outside of `soopervisor`. 

This change makes it so that it always uses the `repository` setting.

Also contains some dependency fixes.
* `pyyaml >= 6.0.2` so that it works with Cython 3+
* Import changes from deprecated `airflow.providers.cncf.kubernetes.operators.kubernetes_pod` to `airflow.providers.cncf.kubernetes.operators.pod`

## Issue ticket number and link
Closes [#130](https://github.com/ploomber/soopervisor/issues/130)

## Checklist before requesting a review
- [ Yes] I have performed a self-review of my code
- [ Yes ] I have added thorough tests (when necessary).
- [ Yes ] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

