### PR TITLE
soopervisor --skip-docker should use the configured repository when running with AWS Batch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     "tqdm",
     "pydantic",
     "Jinja2",
-    "pyyaml",
+    "PyYAML==6.0",
     "ploomber>=0.14.6",
     "ploomber-core>=0.0.11",
     # sdist is generated using python -m build, so adding this here.
@@ -60,6 +60,7 @@ DEV = [
     "kfp",
     # to validate argo specs
     "argo-workflows-dsl",
+    "cython",
     # for testing aws (newer versions break)
     # see: https://github.com/spulec/moto/issues/1793
     "moto==1.3.14",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     "tqdm",
     "pydantic",
     "Jinja2",
-    "PyYAML==6.0",
+    "pyyaml",
     "ploomber>=0.14.6",
     "ploomber-core>=0.0.11",
     # sdist is generated using python -m build, so adding this here.
@@ -60,7 +60,6 @@ DEV = [
     "kfp",
     # to validate argo specs
     "argo-workflows-dsl",
-    "cython",
     # for testing aws (newer versions break)
     # see: https://github.com/spulec/moto/issues/1793
     "moto==1.3.14",

--- a/src/soopervisor/assets/airflow/kubernetes.py
+++ b/src/soopervisor/assets/airflow/kubernetes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from airflow import DAG
 from airflow.utils.dates import days_ago
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
 )
 

--- a/src/soopervisor/aws/batch.py
+++ b/src/soopervisor/aws/batch.py
@@ -283,8 +283,8 @@ class AWSBatchExporter(abc.AbstractExporter):
                 pkg_name, version = source.find_package_name_and_version()
                 default_image_key = get_default_image_key()
                 if default_image_key:
-                    #image_local = f"{pkg_name}:{version}-"
-                    image_local = f"{cfg.repository}:{version}" # use docker image previously created from ECR repository specified in the config file.
+                    # Use image from ECR repository from the config file.
+                    image_local = f"{cfg.repository}:{version}"
                     f"{docker.modify_wildcard(default_image_key)}"
                 image_map = {}
                 image_map[default_image_key] = image_local

--- a/src/soopervisor/aws/batch.py
+++ b/src/soopervisor/aws/batch.py
@@ -283,7 +283,8 @@ class AWSBatchExporter(abc.AbstractExporter):
                 pkg_name, version = source.find_package_name_and_version()
                 default_image_key = get_default_image_key()
                 if default_image_key:
-                    image_local = f"{pkg_name}:{version}-"
+                    #image_local = f"{pkg_name}:{version}-"
+                    image_local = f"{cfg.repository}:{version}" # use docker image previously created from ECR repository specified in the config file.
                     f"{docker.modify_wildcard(default_image_key)}"
                 image_map = {}
                 image_map[default_image_key] = image_local

--- a/tests/airflow/test_airflow_export.py
+++ b/tests/airflow/test_airflow_export.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import json
 
 from airflow import DAG
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
 )
 from airflow.operators.bash import BashOperator

--- a/tests/assets/callables/environment.lock.yml
+++ b/tests/assets/callables/environment.lock.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.8
+  - python=3.9
   - pip
 
   - pip:

--- a/tests/assets/my_project/environment.lock.yml
+++ b/tests/assets/my_project/environment.lock.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.8
+  - python=3.9
   - pip

--- a/tests/assets/my_project/environment.yml
+++ b/tests/assets/my_project/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.8
+  - python=3.9
   - pip

--- a/tests/assets/sample_project/environment.lock.yml
+++ b/tests/assets/sample_project/environment.lock.yml
@@ -2,7 +2,7 @@ name: sample-project-env
 
 dependencies:
   # change the version here if you need to
-  - python=3.8
+  - python=3.9
   # add dependencies here
   - numpy
   - pandas

--- a/tests/assets/sample_project/environment.yml
+++ b/tests/assets/sample_project/environment.yml
@@ -2,7 +2,7 @@ name: sample-project-env
 
 dependencies:
   # change the version here if you need to
-  - python=3.8
+  - python=3.9
   # add dependencies here
   - numpy
   - pandas

--- a/tutorials/airflow/ml-intermediate.py
+++ b/tutorials/airflow/ml-intermediate.py
@@ -5,7 +5,7 @@ from kubernetes.client import models as k8s
 
 from airflow import DAG
 from airflow.utils.dates import days_ago
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
 )
 


### PR DESCRIPTION
## Describe your changes
Right now, when using --skip-docker, the Batch exporter tries to determine the name of the container for the Job definition based on the package the soopervisor.yml file is in, but ideally it'd reuse the configured repository within that file in the Job definition if it's already provided.

## Issue ticket number and link
Closes #130  https://github.com/ploomber/soopervisor/issues/130

## Checklist before requesting a review
- [ *] I have performed a self-review of my code
- [ ] I have added thorough tests (when necessary).
- [ ] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

Tested in AWS Batch, earlier it was submitting task using invalid image. Now, it's able to re-use previously created docker image.

```
 $aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin xxx.dkr.ecr.us-west-2.amazonaws.com/prod-repo && soopervisor export deploy --skip-tests --ignore-git --skip-docker
```
